### PR TITLE
조건부 자동 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-jetty'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-jetty'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/tobyspring/config/MyOnClassCondition.java
+++ b/src/main/java/com/tobyspring/config/MyOnClassCondition.java
@@ -1,0 +1,18 @@
+package com.tobyspring.config;
+
+import com.tobyspring.config.autoconfig.ConditionalMyOnClass;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ClassUtils;
+
+import java.util.Map;
+
+public class MyOnClassCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        Map<String, Object> attrs = metadata.getAnnotationAttributes(ConditionalMyOnClass.class.getName());
+        String value = (String) attrs.get("value");
+        return ClassUtils.isPresent(value, context.getClassLoader());
+    }
+}

--- a/src/main/java/com/tobyspring/config/autoconfig/ConditionalMyOnClass.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/ConditionalMyOnClass.java
@@ -1,0 +1,16 @@
+package com.tobyspring.config.autoconfig;
+
+import com.tobyspring.config.MyOnClassCondition;
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Conditional(MyOnClassCondition.class)
+public @interface ConditionalMyOnClass {
+    String value();
+}

--- a/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
@@ -5,11 +5,23 @@ import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @MyAutoConfiguration
+@Conditional(JettyWebServerConfig.JettyCondition.class)
 public class JettyWebServerConfig {
     @Bean(name = "jettyWebServerFactory")
     public ServletWebServerFactory servletWebServerFactory() {
         return new JettyServletWebServerFactory();
+    }
+
+    static class JettyCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return true; // true 인 경우 @Configuration 클래스 전체가 빈으로 등록된다.
+        }
     }
 }

--- a/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
@@ -1,6 +1,7 @@
 package com.tobyspring.config.autoconfig;
 
 import com.tobyspring.config.MyAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
@@ -15,6 +16,7 @@ import org.springframework.util.ClassUtils;
 @ConditionalMyOnClass("org.eclipse.jetty.server.Server")
 public class JettyWebServerConfig {
     @Bean(name = "jettyWebServerFactory")
+    @ConditionalOnMissingBean
     public ServletWebServerFactory servletWebServerFactory() {
         return new JettyServletWebServerFactory();
     }

--- a/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
@@ -9,19 +9,13 @@ import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ClassUtils;
 
 @MyAutoConfiguration
-@Conditional(JettyWebServerConfig.JettyCondition.class)
+@ConditionalMyOnClass("org.eclipse.jetty.server.Server")
 public class JettyWebServerConfig {
     @Bean(name = "jettyWebServerFactory")
     public ServletWebServerFactory servletWebServerFactory() {
         return new JettyServletWebServerFactory();
-    }
-
-    static class JettyCondition implements Condition {
-        @Override
-        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-            return true; // true 인 경우 @Configuration 클래스 전체가 빈으로 등록된다.
-        }
     }
 }

--- a/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/JettyWebServerConfig.java
@@ -1,15 +1,15 @@
 package com.tobyspring.config.autoconfig;
 
 import com.tobyspring.config.MyAutoConfiguration;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @MyAutoConfiguration
-public class TomcatWebServerConfig {
-    @Bean(name = "tomcatWebServerFactory")
+public class JettyWebServerConfig {
+    @Bean(name = "jettyWebServerFactory")
     public ServletWebServerFactory servletWebServerFactory() {
-        return new TomcatServletWebServerFactory();
+        return new JettyServletWebServerFactory();
     }
 }

--- a/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
@@ -1,20 +1,17 @@
 package com.tobyspring.config.autoconfig;
 
 import com.tobyspring.config.MyAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.util.ClassUtils;
 
 @MyAutoConfiguration
 @ConditionalMyOnClass("org.apache.catalina.startup.Tomcat")
 public class TomcatWebServerConfig {
     @Bean(name = "tomcatWebServerFactory")
+    @ConditionalOnMissingBean
     public ServletWebServerFactory servletWebServerFactory() {
         return new TomcatServletWebServerFactory();
     }

--- a/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
@@ -5,21 +5,17 @@ import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactor
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ClassUtils;
 
 @MyAutoConfiguration
-@Conditional(TomcatWebServerConfig.TomcatCondition.class)
+@ConditionalMyOnClass("org.apache.catalina.startup.Tomcat")
 public class TomcatWebServerConfig {
     @Bean(name = "tomcatWebServerFactory")
     public ServletWebServerFactory servletWebServerFactory() {
         return new TomcatServletWebServerFactory();
-    }
-
-    static class TomcatCondition implements Condition {
-        @Override
-        public boolean matches(org.springframework.context.annotation.ConditionContext context, org.springframework.core.type.AnnotatedTypeMetadata metadata) {
-            return false;
-        }
     }
 }

--- a/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
+++ b/src/main/java/com/tobyspring/config/autoconfig/TomcatWebServerConfig.java
@@ -4,12 +4,22 @@ import com.tobyspring.config.MyAutoConfiguration;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @MyAutoConfiguration
+@Conditional(TomcatWebServerConfig.TomcatCondition.class)
 public class TomcatWebServerConfig {
     @Bean(name = "tomcatWebServerFactory")
     public ServletWebServerFactory servletWebServerFactory() {
         return new TomcatServletWebServerFactory();
+    }
+
+    static class TomcatCondition implements Condition {
+        @Override
+        public boolean matches(org.springframework.context.annotation.ConditionContext context, org.springframework.core.type.AnnotatedTypeMetadata metadata) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/tobyspring/helloboot/WebServerConfiguration.java
+++ b/src/main/java/com/tobyspring/helloboot/WebServerConfiguration.java
@@ -1,0 +1,17 @@
+package com.tobyspring.helloboot;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class WebServerConfiguration {
+    @Bean // ComponentScan 이 먼저 등록됨 ( AutoConfiguration 보다 )
+    ServletWebServerFactory customServletWebServerFactory() {
+        TomcatServletWebServerFactory serverFactory = new TomcatServletWebServerFactory();
+        serverFactory.setPort(9090);
+
+        return serverFactory;
+    }
+}

--- a/src/main/resources/META-INF/spring/com.tobyspring.config.MyAutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/com.tobyspring.config.MyAutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.tobyspring.config.autoconfig.TomcatWebServerConfig
 com.tobyspring.config.autoconfig.DispatcherServletConfig
+com.tobyspring.config.autoconfig.JettyWebServerConfig

--- a/src/test/java/com/tobyspring/study/ConditionalTest.java
+++ b/src/test/java/com/tobyspring/study/ConditionalTest.java
@@ -1,0 +1,74 @@
+package com.tobyspring.study;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.*;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ConditionalTest {
+
+    @Test
+    void conditional() {
+        // true 인 경우
+        ApplicationContextRunner runner = new ApplicationContextRunner()
+                .withUserConfiguration(Config1.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(MyBean.class);
+                    assertThat(context).hasSingleBean(Config1.class);
+                });
+
+        // false 인 경우
+        ApplicationContextRunner runner2 = new ApplicationContextRunner()
+                .withUserConfiguration(Config2.class)
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(MyBean.class);
+                    assertThat(context).doesNotHaveBean(Config2.class);
+                });
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Conditional(BooleanCondition.class)
+    @interface BooleanConditional {
+        boolean value();
+    }
+
+    @Configuration
+    @BooleanConditional(true)
+    static class Config1 {
+
+        @Bean
+        MyBean myBean() {
+            return new MyBean();
+        }
+    }
+
+    @Configuration
+    @BooleanConditional(false)
+    static class Config2 {
+
+        @Bean
+        MyBean myBean() {
+            return new MyBean();
+        }
+    }
+
+    static class BooleanCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return (boolean) metadata.getAnnotationAttributes(BooleanConditional.class.getName()).get("value");
+        }
+    }
+
+    static class MyBean {
+
+    }
+}


### PR DESCRIPTION
`@Conditional` 을 활용하여 AutoConfiguration 으로 빈이 등록될지, 등록이 안될지 설정해보았음

직접 Condtion Interface 를 상속받아 matches method 를 오버라이딩하여 현재 내가 추가한 dependency 에 경로가 있을 경우 빈으로 등록하고, 그렇지 않으면 빈으로 등록되지 않게끔 설정해주었음

추가로 ComponentScan 이 AutoConfiguration 보다 먼저 진행되기 때문에, tomcat bean 을 2개를 띄워 일부러 충돌시켜보았음

`@Conditional` 의 세부 애노테이션인 `@ConditionalOnMissingBean` 을 활용하여 빈으로 등록이 되어있을 경우, AutoConfiguration 에선 빈으로 등록되지 않게끔 설정해주었음

This closes #12 